### PR TITLE
Add ability to import settings from a URL parameter.

### DIFF
--- a/src/data/Settings.js
+++ b/src/data/Settings.js
@@ -134,6 +134,13 @@ const default_settings = {
 class Settings {
 	loadSettings() {
 		return new Promise((resolve, reject) => {
+			const params = new URLSearchParams(window.location.search);
+			const s = params.get('settings');
+			if (s !== null) {
+				this.importSettings(s)
+				resolve();
+				return;
+			}
 			localForage.getItem("settings_cache")
 				.then((data) => {
 					this.mergeSettings(data);


### PR DESCRIPTION
This improves the quality of life for using the overlay with OBS.

Currently, the state of the art for using an overlay with OBS seems to be using ACT-websocket with the OBS BrowserSource plugin. To configure the overlay settings, we need to use the "Interact" option with the BrowserSource to adjust them manually. We can work around the fact that there's no persistent local storage in the BrowserSource plugin by importing the settings through a URL parameter.