### PR TITLE
Update cd for AST umbral/astral draw.

### DIFF
--- a/src/data/game/ogcd-skills.json
+++ b/src/data/game/ogcd-skills.json
@@ -12299,7 +12299,7 @@
 		}
 	},
 	"37017" : {
-		"recast" : 60.0,
+		"recast" : 55.0,
 		"charges" : 0,
 		"level_recasts" : null,
 		"level_charges" : null,
@@ -12317,7 +12317,7 @@
 		}
 	},
 	"37018" : {
-		"recast" : 60.0,
+		"recast" : 55.0,
 		"charges" : 0,
 		"level_recasts" : null,
 		"level_charges" : null,


### PR DESCRIPTION
CDs for astral/umbral draw are currently at 60s, but [7.01](https://na.finalfantasyxiv.com/lodestone/topics/detail/0ad1ca4bbafeb2ee244994bee15b3a74c0278e1d/) updated these cds to 55s.